### PR TITLE
Rakefile install task is broken.

### DIFF
--- a/clients/ruby/Rakefile
+++ b/clients/ruby/Rakefile
@@ -44,7 +44,7 @@ end
 
 desc "install the gem locally"
 task :install => [:package] do
-  sh %{sudo gem install pkg/#{GEM_NAME}-#{GEM_VERSION}}
+  sh %{sudo gem install pkg/#{GEM}-#{GEM_VERSION}}
 end
 
 desc "create a gemspec file"


### PR DESCRIPTION
Currently the Ruby client's Rakefile tries to install based on the gem's name, resulting in:
    ~/repos/kafka/clients/ruby> rake -f Rakefile install  
    (in /Users/jhoman/repos/kafka/clients/ruby)  
    mkdir -p pkg  
      Successfully built RubyGem  
      Name: kafka-rb  
      Version: 0.0.5  
      File: kafka-rb-0.0.5.gem  
    mv kafka-rb-0.0.5.gem pkg/kafka-rb-0.0.5.gem  
    sudo gem install pkg/Kafka Client-0.0.5  
    Password:  
    ERROR:  could not find gem pkg/Kafka locally or in a repository  
    ERROR:  could not find gem Client-0.0.5 locally or in a repository  
    rake aborted!        

It should be looking for the gem filename itself.  After this patch:
~/repos/kafka/clients/ruby> rake -f Rakefile install
    ~/repos/kafka/clients/ruby> rake -f Rakefile install  
    (in /Users/jhoman/repos/kafka/clients/ruby)  
      Successfully built RubyGem  
      Name: kafka-rb  
      Version: 0.0.5  
      File: kafka-rb-0.0.5.gem  
    mv kafka-rb-0.0.5.gem pkg/kafka-rb-0.0.5.gem  
    sudo gem install pkg/kafka-rb-0.0.5  
    Successfully installed kafka-rb-0.0.5  
    1 gem installed  
    Installing ri documentation for kafka-rb-0.0.5...  
    Installing RDoc documentation for kafka-rb-0.0.5...    
