### PR TITLE
Set default partition to -1

### DIFF
--- a/clients/php/src/lib/Kafka/Producer.php
+++ b/clients/php/src/lib/Kafka/Producer.php
@@ -89,7 +89,7 @@ class Kafka_Producer
 	 *
 	 * @return boolean
 	 */
-	public function send(array $messages, $topic, $partition = 0) {
+	public function send(array $messages, $topic, $partition = 0xFFFFFFFF) {
 		$this->connect();
 		return fwrite($this->conn, Kafka_Encoder::encode_produce_request($topic, $partition, $messages));
 	}


### PR DESCRIPTION
In the PHP Producer, the default partition in the send() method was set to 0, it's now set to -1 (in 2 complement).
