### PR TITLE
KAFKA-69: Confusing error mesage from producer when no kafka brokers are available.

### DIFF
--- a/core/src/main/scala/kafka/common/NoBrokersForPartitionException.scala
+++ b/core/src/main/scala/kafka/common/NoBrokersForPartitionException.scala
@@ -1,0 +1,9 @@
+package kafka.common
+
+/**
+ * Thrown when a request is made for broker but no brokers with that topic
+ * exist.
+ */
+class NoBrokersForPartitionException(message: String) extends RuntimeException(message) {
+  def this() = this(null)
+}

--- a/core/src/main/scala/kafka/javaapi/producer/Producer.scala
+++ b/core/src/main/scala/kafka/javaapi/producer/Producer.scala
@@ -29,7 +29,7 @@ class Producer[K,V](config: ProducerConfig,
                                                           /* use the other constructor*/
 {
 
-  private val underlying = new kafka.producer.Producer[K,V](config, partitioner, producerPool, populateProducerPool)
+  private val underlying = new kafka.producer.Producer[K,V](config, partitioner, producerPool, populateProducerPool, null)
 
   /**
    * This constructor can be used when all config parameters will be specified through the

--- a/core/src/main/scala/kafka/producer/BrokerPartitionInfo.scala
+++ b/core/src/main/scala/kafka/producer/BrokerPartitionInfo.scala
@@ -19,11 +19,12 @@ import collection.mutable.Map
 import collection.SortedSet
 import kafka.cluster.{Broker, Partition}
 
-private[producer] trait BrokerPartitionInfo {
+trait BrokerPartitionInfo {
   /**
-   * Return a sequence of (brokerId, numPartitions) 
+   * Return a sequence of (brokerId, numPartitions).
    * @param topic the topic for which this information is to be returned
-   * @return a sequence of (brokerId, numPartitions) 
+   * @return a sequence of (brokerId, numPartitions). Returns a zero-length
+   * sequence if no brokers are available.
    */  
   def getBrokerPartitionInfo(topic: String = null): SortedSet[Partition]
 

--- a/core/src/main/scala/kafka/producer/ZKBrokerPartitionInfo.scala
+++ b/core/src/main/scala/kafka/producer/ZKBrokerPartitionInfo.scala
@@ -85,7 +85,8 @@ private[producer] class ZKBrokerPartitionInfo(config: ZKConfig, producerCbk: (In
   /**
    * Return a sequence of (brokerId, numPartitions)
    * @param topic the topic for which this information is to be returned
-   * @return a sequence of (brokerId, numPartitions)
+   * @return a sequence of (brokerId, numPartitions). Returns a zero-length
+   * sequence if no brokers are available.
    */
   def getBrokerPartitionInfo(topic: String): scala.collection.immutable.SortedSet[Partition] = {
     val brokerPartitions = topicBrokerPartitions.get(topic)

--- a/core/src/main/scala/kafka/tools/ProducerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ProducerPerformance.scala
@@ -148,8 +148,7 @@ object ProducerPerformance {
     props.put("reconnect.interval", Integer.MAX_VALUE.toString)
     props.put("buffer.size", (64*1024).toString)
 
-    val producer = new Producer[String, String](new ProducerConfig(props), new StringEncoder, new DefaultEventHandler, null,
-      new DefaultPartitioner)
+    val producer = new Producer[String, String](new ProducerConfig(props), new StringEncoder, new DefaultEventHandler[String], null, new DefaultPartitioner[String])
 
     override def run {
       var bytesSent = 0L
@@ -210,8 +209,8 @@ object ProducerPerformance {
     props.put("reconnect.interval", Integer.MAX_VALUE.toString)
     props.put("buffer.size", (64*1024).toString)
 
-    val producer = new Producer[String, String](new ProducerConfig(props), new StringEncoder, new DefaultEventHandler, null,
-      new DefaultPartitioner)
+    val producer = new Producer[String, String](new ProducerConfig(props), new StringEncoder, new DefaultEventHandler[String], null,
+      new DefaultPartitioner[String])
 
     override def run {
       var bytesSent = 0L

--- a/core/src/test/scala/unit/kafka/producer/ProducerMethodsTest.scala
+++ b/core/src/test/scala/unit/kafka/producer/ProducerMethodsTest.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2011 LinkedIn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package unit.kafka.producer
+
+import collection.immutable.SortedSet
+import java.util._
+import junit.framework.Assert._
+import kafka.cluster.Partition
+import kafka.common.NoBrokersForPartitionException
+import kafka.producer._
+import org.easymock.EasyMock
+import org.junit.Test
+import org.scalatest.junit.JUnitSuite
+import scala.collection.immutable.List
+
+class ProducerMethodsTest extends JUnitSuite {
+
+  @Test
+  def producerThrowsNoBrokersException() = {
+    val props = new Properties
+    props.put("broker.list", "placeholder") // Need to fake out having specified one
+    val config = new ProducerConfig(props)
+    val mockPartitioner = EasyMock.createMock(classOf[Partitioner[String]])
+    val mockProducerPool = EasyMock.createMock(classOf[ProducerPool[String]])
+    val mockBrokerPartitionInfo = EasyMock.createMock(classOf[kafka.producer.BrokerPartitionInfo])
+
+    EasyMock.expect(mockBrokerPartitionInfo.getBrokerPartitionInfo("the_topic")).andReturn(SortedSet[Partition]())
+    EasyMock.replay(mockBrokerPartitionInfo)
+
+    val producer = new Producer[String, String](config,mockPartitioner, mockProducerPool,false, mockBrokerPartitionInfo)
+
+    try {
+      val producerData = new ProducerData[String, String]("the_topic", "the_key", List("the_datum"))
+      producer.send(producerData)
+      fail("Should have thrown a NoBrokersForPartitionException.")
+    } catch {
+      case nb: NoBrokersForPartitionException => assertTrue(nb.getMessage.contains("the_key"))
+    }
+
+  }
+}

--- a/core/src/test/scala/unit/kafka/producer/ProducerTest.scala
+++ b/core/src/test/scala/unit/kafka/producer/ProducerTest.scala
@@ -129,7 +129,7 @@ class ProducerTest extends JUnitSuite {
     syncProducers.put(brokerId2, syncProducer2)
 
     val producerPool = new ProducerPool(config, serializer, syncProducers, new ConcurrentHashMap[Int, AsyncProducer[String]]())
-    val producer = new Producer[String, String](config, partitioner, producerPool, false)
+    val producer = new Producer[String, String](config, partitioner, producerPool, false, null)
 
     producer.send(new ProducerData[String, String](topic, "test", Array("test1")))
     producer.close
@@ -163,7 +163,7 @@ class ProducerTest extends JUnitSuite {
 
     val producerPool = new ProducerPool[String](config, serializer, syncProducers,
       new ConcurrentHashMap[Int, AsyncProducer[String]]())
-    val producer = new Producer[String, String](config, partitioner, producerPool, false)
+    val producer = new Producer[String, String](config, partitioner, producerPool, false, null)
 
     producer.send(new ProducerData[String, String](topic, "t"))
     producer.close
@@ -380,7 +380,7 @@ class ProducerTest extends JUnitSuite {
     asyncProducers.put(brokerId1, asyncProducer1)
 
     val producerPool = new ProducerPool(config, serializer, new ConcurrentHashMap[Int, SyncProducer](), asyncProducers)
-    val producer = new Producer[String, String](config, partitioner, producerPool, false)
+    val producer = new Producer[String, String](config, partitioner, producerPool, false, null)
 
     producer.send(new ProducerData[String, String](topic, "test1", Array("test1")))
     producer.close
@@ -544,7 +544,7 @@ class ProducerTest extends JUnitSuite {
     syncProducers.put(brokerId2, syncProducer2)
 
     val producerPool = new ProducerPool(config, serializer, syncProducers, new ConcurrentHashMap[Int, AsyncProducer[String]]())
-    val producer = new Producer[String, String](config, partitioner, producerPool, false)
+    val producer = new Producer[String, String](config, partitioner, producerPool, false, null)
 
     producer.send(new ProducerData[String, String]("test-topic1", "test", Array("test1")))
     Thread.sleep(100)
@@ -596,7 +596,7 @@ class ProducerTest extends JUnitSuite {
     syncProducers.put(2, syncProducer3)
 
     val producerPool = new ProducerPool(config, serializer, syncProducers, new ConcurrentHashMap[Int, AsyncProducer[String]]())
-    val producer = new Producer[String, String](config, partitioner, producerPool, false)
+    val producer = new Producer[String, String](config, partitioner, producerPool, false, null)
 
     val serverProps = TestUtils.createBrokerConfig(2, 9094)
     val serverConfig = new KafkaConfig(serverProps) {
@@ -648,7 +648,7 @@ class ProducerTest extends JUnitSuite {
     asyncProducers.put(brokerId1, asyncProducer1)
 
     val producerPool = new ProducerPool(config, serializer, new ConcurrentHashMap[Int, SyncProducer](), asyncProducers)
-    val producer = new Producer[String, String](config, partitioner, producerPool, false)
+    val producer = new Producer[String, String](config, partitioner, producerPool, false, null)
 
     producer.send(new ProducerData[String, String](topic, "test", Array("test1")))
     producer.close


### PR DESCRIPTION
Patch for KAFKA-69.

Patch:
- Adds new NoBrokersAvailableForPartition, which is thrown when the Producer can't find any brokers.  This is what's actually happening in the failure mode describe.
- Adds new unit test for this behavior.  Had to inject a BrokerPartitionInfo into the Producer to do this, creating a new constructor.  This constructor confuses scalac, so had to add some extra, explicit type info to calls to the Producer class.
- The packaging for the tests is a bit messed up, with an extra level (unit) that breaks the correspondence and prevents the tests from accessing package private classes.  As such, had to make BrokerPartitionInfo public temporarily.  Will open a new issue to fix the packaging and make BrokerPartitionInfo package private again when it's fixed.
- I notice that quite a few lines of Producer are involved with branching and configuring different implementations of BrokerPartitionInfo.  Will go ahead and see if I can improve this via polymorphism and open a new issue.

Tests pass. 
