### PR TITLE
KAFKA-74 (zk topic discovery for mirroring)

### DIFF
--- a/core/src/main/scala/kafka/consumer/TopicEventHandler.scala
+++ b/core/src/main/scala/kafka/consumer/TopicEventHandler.scala
@@ -12,7 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
+
 package kafka.consumer
 
 trait TopicEventHandler[T] {

--- a/core/src/main/scala/kafka/consumer/TopicEventHandler.scala
+++ b/core/src/main/scala/kafka/consumer/TopicEventHandler.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2010 LinkedIn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package kafka.consumer
+
+trait TopicEventHandler[T] {
+
+  def handleTopicEvent(
+    addedTopics: Seq[T], deletedTopics: Seq[T], allTopics: Seq[T])
+
+}

--- a/core/src/main/scala/kafka/consumer/ZookeeperTopicEventWatcher.scala
+++ b/core/src/main/scala/kafka/consumer/ZookeeperTopicEventWatcher.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2010 LinkedIn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.consumer
+
+import org.apache.log4j.Logger
+import org.I0Itec.zkclient.{IZkChildListener, ZkClient}
+import kafka.utils.{ZkUtils, StringSerializer}
+import scala.collection.JavaConversions._
+import collection.immutable.List
+
+class ZookeeperTopicEventWatcher(val config:ConsumerConfig,
+    val eventHandler: Option[TopicEventHandler[String]]) {
+
+  private val logger = Logger.getLogger(getClass)
+  private val zkClient: ZkClient = new ZkClient(config.zkConnect, config.zkSessionTimeoutMs,
+      config.zkConnectionTimeoutMs, StringSerializer)
+  var topics: List[String] = List()
+
+  watchTopicEvents()
+
+  def this(config:ConsumerConfig) {
+    this(config, null)
+  }
+
+  private def watchTopicEvents() {
+    val topicEventListener = new ZkTopicEventListener
+    ZkUtils.makeSurePersistentPathExists(zkClient, ZkUtils.brokerTopicsPath)
+    zkClient.subscribeChildChanges(ZkUtils.brokerTopicsPath, topicEventListener)
+  }
+
+  class ZkTopicEventListener() extends IZkChildListener {
+
+    @throws(classOf[Exception])
+    def handleChildChange(parent: String, children: java.util.List[String]) {
+      val latestTopics = children.toList
+
+      val addedTopics = latestTopics filterNot (topics contains)
+      val deletedTopics = topics filterNot (latestTopics contains)
+
+      eventHandler match {
+        case Some(handler) => {
+          handler.handleTopicEvent(addedTopics, deletedTopics, latestTopics)
+        }
+        case None => {
+          logger.debug("ignoring topic event (no event handler registered)")
+        }
+      }
+
+      topics = latestTopics
+    }
+  }
+}
+

--- a/core/src/test/scala/unit/kafka/consumer/ZookeeperTopicEventWatcherTest.scala
+++ b/core/src/test/scala/unit/kafka/consumer/ZookeeperTopicEventWatcherTest.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010 LinkedIn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package unit.kafka.consumer
 
 import org.scalatest.junit.JUnit3Suite

--- a/core/src/test/scala/unit/kafka/consumer/ZookeeperTopicEventWatcherTest.scala
+++ b/core/src/test/scala/unit/kafka/consumer/ZookeeperTopicEventWatcherTest.scala
@@ -1,0 +1,78 @@
+package unit.kafka.consumer
+
+import org.scalatest.junit.JUnit3Suite
+import junit.framework.Assert._
+import kafka.zk.ZooKeeperTestHarness
+import org.I0Itec.zkclient.ZkClient
+import kafka.utils.{StringSerializer, ZkUtils, TestUtils, TestZKUtils}
+import org.apache.log4j.{Level, Logger}
+import java.util.Properties
+import kafka.consumer.{TopicEventHandler, ConsumerConfig, ZookeeperTopicEventWatcher}
+
+class ZookeeperTopicEventWatcherTest extends JUnit3Suite
+  with ZooKeeperTestHarness with TopicEventHandler[String] {
+
+  private val logger = Logger.getLogger(getClass)
+  logger.setLevel(Level.INFO)
+
+  private def pathToTopic(i: Int) = {
+    "%s/%s-%d".format(ZkUtils.brokerTopicsPath, "topic", i)
+  }
+
+  def handleTopicEvent(addedTopics: Seq[String], deletedTopics: Seq[String],
+                       allTopics: Seq[String]) {
+//    logger.info("event handler:")
+//    for (val topic <- addedTopics) {
+//      logger.info("\tadded topic %s".format(topic))
+//    }
+//    for (val topic <- deletedTopics) {
+//      logger.info("\tdeleted topic %s".format(topic))
+//    }
+  }
+
+  val zkConnect = TestZKUtils.zookeeperConnect
+
+  private val consumerConfig = new ConsumerConfig(
+    TestUtils.createConsumerProperties(
+      zkConnect, "groupid_dontcare", "consumerid_dontcare"))
+
+  def testAll() {
+    val numTopicsToAdd = 100
+    val numTopicsToDelete = 10 % numTopicsToAdd
+
+    val zkClient = new ZkClient(zkConnect, consumerConfig.zkSessionTimeoutMs,
+      consumerConfig.zkConnectionTimeoutMs, StringSerializer)
+
+    // start with no topics
+    val topicEventWatcher = new ZookeeperTopicEventWatcher(
+      consumerConfig, Some(this))
+    assertEquals(topicEventWatcher.topics.size, 0)
+
+    // add a few topics
+    for (topicNum <- 1 to numTopicsToAdd)
+      ZkUtils.createEphemeralPathExpectConflict(
+        zkClient, pathToTopic(topicNum), "data_dontcare")
+
+    Thread.sleep(2000)
+
+    assertEquals(topicEventWatcher.topics.size, numTopicsToAdd)
+
+    // delete some topics
+    for (topicNum <- 1 to numTopicsToDelete)
+      ZkUtils.deletePath(zkClient, pathToTopic(topicNum))
+
+    Thread.sleep(2000)
+
+    assertEquals(topicEventWatcher.topics.size,
+      numTopicsToAdd - numTopicsToDelete)
+
+    // delete all topics
+    for (topicNum <- numTopicsToDelete to numTopicsToAdd)
+      ZkUtils.deletePath(zkClient, pathToTopic(topicNum))
+
+    Thread.sleep(2000)
+
+    assertEquals(topicEventWatcher.topics.size, 0)
+  }
+
+}


### PR DESCRIPTION
This is an initial review request, as I need to do some more thorough testing. (so don't commit yet :) )

The basic approach is to register a topic listener on the broker topic registry. When topics are added/deleted, the embedded consumer's consumer connector is shut down and restarted with the new list of topics.

The patch also includes a config change with an effort to support the older config - if that looks unnecessarily complicated we can get rid of it and insist on a new config.
