### PR TITLE
[KAFKA-16] Added an optional acknowledgement in the producer

### DIFF
--- a/core/src/main/scala/kafka/api/AckResponse.scala
+++ b/core/src/main/scala/kafka/api/AckResponse.scala
@@ -1,10 +1,10 @@
 /*
  * Copyright 2010 LinkedIn
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -16,11 +16,20 @@
 
 package kafka.api
 
-object RequestKeys {
-  val Produce: Short = 0
-  val Fetch: Short = 1
-  val MultiFetch: Short = 2
-  val MultiProduce: Short = 3
-  val Offsets: Short = 4
-  val AckedProduce : Short = 5
+import java.nio._
+import java.nio.channels._
+import kafka.network._
+import kafka.utils._
+
+/**
+ * A simple ack to send to producer
+ */
+@threadsafe
+object AckResponse extends Send {
+  def writeTo(channel: WritableByteChannel): Int = channel.write(ByteBuffer.wrap(Array(1)))
+  def complete = true
+  def readFrom(buffer: ByteBuffer) =
+      if (buffer.limit() == 1 && buffer.get() == 1) AckResponse
+      else throw new IllegalArgumentException("Bad AckSend buffer")
+
 }

--- a/core/src/main/scala/kafka/api/ProducerRequest.scala
+++ b/core/src/main/scala/kafka/api/ProducerRequest.scala
@@ -80,3 +80,21 @@ class ProducerRequest(val topic: String,
   override def hashCode: Int = 31 + (17 * partition) + topic.hashCode + messages.hashCode
 
 }
+
+/**
+ * Same as ProducerRequest, only the id changes
+ */
+class AckedProducerRequest(override val topic : String,
+                           override val partition : Int,
+                           override val messages : ByteBufferMessageSet
+                         ) extends ProducerRequest(topic, partition, messages){
+  override val id = RequestKeys.AckedProduce
+  override def toString: String = "Acked" + super.toString
+  override def equals(other: Any) : Boolean = {
+    other match {
+      case that: AckedProducerRequest => that.isInstanceOf[AckedProducerRequest] && super.equals(that)
+      case _ => false
+    }
+  }
+}
+

--- a/core/src/main/scala/kafka/producer/ProducerPool.scala
+++ b/core/src/main/scala/kafka/producer/ProducerPool.scala
@@ -76,6 +76,7 @@ class ProducerPool[V](private val config: ProducerConfig,
         props.put("buffer.size", config.bufferSize.toString)
         props.put("connect.timeout.ms", config.connectTimeoutMs.toString)
         props.put("reconnect.interval", config.reconnectInterval.toString)
+        props.put("ack.needed", config.ackNeeded.toString)
         val producer = new SyncProducer(new SyncProducerConfig(props))
         logger.info("Creating sync producer for broker id = " + broker.id + " at " + broker.host + ":" + broker.port)
         syncProducers.put(broker.id, producer)

--- a/core/src/main/scala/kafka/producer/SyncProducerConfig.scala
+++ b/core/src/main/scala/kafka/producer/SyncProducerConfig.scala
@@ -41,4 +41,8 @@ trait SyncProducerConfigShared {
   val reconnectInterval = Utils.getInt(props, "reconnect.interval", 30000)
 
   val maxMessageSize = Utils.getInt(props, "max.message.size", 1000000)
+
+  /** wether we wait or not for ACK after sending */
+  val ackNeeded = Utils.getBoolean(props, "ack.needed", false)
+
 }


### PR DESCRIPTION
For Sync producers, the ack.needed=true option will make the producer wait for
an Ack from the server after the send()
Missing tests, just wanted to know if I'm on the right path.
